### PR TITLE
Added missing displayName

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,8 @@ var React = require('react'),
  *     });
  */
 var DocumentTitle = React.createClass({
+  displayName: 'DocumentTitle',
+
   propTypes: {
     title: PropTypes.string
   },

--- a/test/common.js
+++ b/test/common.js
@@ -6,6 +6,11 @@ var expect = require('expect.js'),
     DocumentTitle = require('../');
 
 describe('DocumentTitle', function () {
+  it('has a displayName', function () {
+    var el = React.createElement(DocumentTitle);
+    expect(el.type.displayName).to.be.a('string');
+    expect(el.type.displayName).not.to.be.empty();
+  });
   it('hides itself from the DOM', function () {
     var Component = React.createClass({
       render: function () {


### PR DESCRIPTION
The `displayName` property is useful for debugging and is set automatically if JSX component definitions are converted to JS.

This change makes `DocumentTitle` elements show up as `DocumentTitle` instead of `Unknown` in development tools.
