### PR TITLE
Add bower.json file for react-document-title

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "react-document-title",
+  "main": "index.js",
+  "version": "1.0.2",
+  "homepage": "https://github.com/gaearon/react-document-title",
+  "authors": [
+    "Dan Abramov <dan.abramov@me.com>"
+  ],
+  "description": "Provides a declarative way to specify document.title in a single-page app. This component can be used on server side as well.",
+  "keywords": [
+    "react",
+    "document",
+    "title"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
If you're cool with this, I can also register this (http://bower.io/docs/creating-packages/#register). Just needed it to be in bower as my current project has a convention to only load in packages via bower.