### PR TITLE
Update react-side-effect dependency to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "react": "^0.13.0"
   },
   "dependencies": {
-    "react-side-effect": "^1.0.0"
+    "react-side-effect": "^1.0.2"
   }
 }


### PR DESCRIPTION
Fixes warning about 

Warning: SideEffect(Component)(...): React component classes must extend React.Component