### PR TITLE
Bring back displayName

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ function handleStateChangeOnClient(title) {
 }
 
 var DocumentTitle = React.createClass({
+  displayName: 'DocumentTitle',
+
   propTypes: {
     title: React.PropTypes.string.isRequired
   },

--- a/test/common.js
+++ b/test/common.js
@@ -14,6 +14,7 @@ describe('DocumentTitle', function () {
     var el = React.createElement(DocumentTitle);
     expect(el.type.displayName).to.be.a('string');
     expect(el.type.displayName).not.to.be.empty();
+    expect(el.type.displayName).to.equal('SideEffect(DocumentTitle)');
   });
   it('hides itself from the DOM', function () {
     var Component = React.createClass({


### PR DESCRIPTION
This PR fixes lost `displayName` and adds more precise test for that.