### PR TITLE
Check if title should be updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ function reducePropsToState(propsList) {
 }
 
 function handleStateChangeOnClient(title) {
-  if (title !== document.title) {
-    document.title = title || '';
+  var nextTitle = title || '';
+  if (nextTitle !== document.title) {
+    document.title = nextTitle;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ function reducePropsToState(propsList) {
 }
 
 function handleStateChangeOnClient(title) {
-  document.title = title || '';
+  if (title !== document.title) {
+    document.title = title || '';
+  }
 }
 
 var DocumentTitle = React.createClass({


### PR DESCRIPTION
This change prevents the document.title of being updated regardless if it had changed or not.

When using DocumentTitle today, any time some child component updates, the current document.title updates as well, and it shouldn't.