### PR TITLE
Use packages to prevent React v15.5.0 and up from complaining about deprecated API's

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react'),
+    PropTypes = require('prop-types'),
+    createReactClass = require('create-react-class'),
     withSideEffect = require('react-side-effect');
 
 function reducePropsToState(propsList) {
@@ -17,11 +19,11 @@ function handleStateChangeOnClient(title) {
   }
 }
 
-var DocumentTitle = React.createClass({
+var DocumentTitle = createReactClass({
   displayName: 'DocumentTitle',
 
   propTypes: {
-    title: React.PropTypes.string.isRequired
+    title: PropTypes.string.isRequired
   },
 
   render: function render() {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var React = require('react'),
     PropTypes = require('prop-types'),
-    createReactClass = require('create-react-class'),
     withSideEffect = require('react-side-effect');
 
 function reducePropsToState(propsList) {
@@ -19,21 +18,21 @@ function handleStateChangeOnClient(title) {
   }
 }
 
-var DocumentTitle = createReactClass({
-  displayName: 'DocumentTitle',
+function DocumentTitle() {}
+DocumentTitle.prototype = Object.create(React.Component.prototype);
 
-  propTypes: {
-    title: PropTypes.string.isRequired
-  },
+DocumentTitle.displayName = 'DocumentTitle';
+DocumentTitle.propTypes = {
+  title: PropTypes.string.isRequired
+};
 
-  render: function render() {
-    if (this.props.children) {
-      return React.Children.only(this.props.children);
-    } else {
-      return null;
-    }
+DocumentTitle.prototype.render = function() {
+  if (this.props.children) {
+    return React.Children.only(this.props.children);
+  } else {
+    return null;
   }
-});
+};
 
 module.exports = withSideEffect(
   reducePropsToState,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": "^0.13.0"
   },
   "dependencies": {
-    "create-react-class": "^15.5.1",
     "prop-types": "^15.5.6",
     "react-side-effect": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/gaearon/react-document-title",
   "devDependencies": {
+    "create-react-class": "^15.5.2",
     "expect.js": "^0.3.1",
     "global": "^4.3.0",
     "jshint": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "react": "^0.13.0"
   },
   "dependencies": {
+    "create-react-class": "^15.5.1",
+    "prop-types": "^15.5.6",
     "react-side-effect": "^1.0.2"
   }
 }

--- a/test/browser.js
+++ b/test/browser.js
@@ -3,6 +3,7 @@
 'use strict';
 var expect = require('expect.js'),
     React = require('react'),
+    createReactClass = require('create-react-class'),
     DocumentTitle = require('../');
 
 describe('DocumentTitle (in a browser)', function () {
@@ -27,7 +28,7 @@ describe('DocumentTitle (in a browser)', function () {
   });
   it('changes the document title on mount', function (done) {
     var title = 'hello world';
-    var Component = React.createClass({
+    var Component = createReactClass({
       componentDidMount: function () {
         expect(global.document.title).to.equal(title);
         done();
@@ -41,7 +42,7 @@ describe('DocumentTitle (in a browser)', function () {
   it('supports nesting', function (done) {
     var called = false;
     var title = 'hello world';
-    var Component1 = React.createClass({
+    var Component1 = createReactClass({
       componentDidMount: function () {
         setTimeout(function () {
           expect(called).to.be(true);
@@ -53,7 +54,7 @@ describe('DocumentTitle (in a browser)', function () {
         return React.createElement(DocumentTitle, {title: title});
       }
     });
-    var Component2 = React.createClass({
+    var Component2 = createReactClass({
       componentDidMount: function () {
         called = true;
       },

--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,7 @@
 'use strict';
 var expect = require('expect.js'),
     React = require('react'),
+    createReactClass = require('create-react-class'),
     DocumentTitle = require('../');
 
 describe('DocumentTitle', function () {
@@ -17,7 +18,7 @@ describe('DocumentTitle', function () {
     expect(el.type.displayName).to.equal('SideEffect(DocumentTitle)');
   });
   it('hides itself from the DOM', function () {
-    var Component = React.createClass({
+    var Component = createReactClass({
       render: function () {
         return React.createElement(DocumentTitle, {title: 'irrelevant'},
           React.createElement('div', null, 'hello')
@@ -28,7 +29,7 @@ describe('DocumentTitle', function () {
     expect(markup).to.equal('<div>hello</div>');
   });
   it('throws an error if it has multiple children', function (done) {
-    var Component = React.createClass({
+    var Component = createReactClass({
       render: function () {
         return React.createElement(DocumentTitle, {title: 'irrelevant'},
           React.createElement('div', null, 'hello'),
@@ -44,7 +45,7 @@ describe('DocumentTitle', function () {
     });
   });
   it('works with complex children', function () {
-    var Component1 = React.createClass({
+    var Component1 = createReactClass({
       render: function() {
         return React.createElement('p', null,
           React.createElement('span', null, 'c'),
@@ -52,7 +53,7 @@ describe('DocumentTitle', function () {
         );
       }
     });
-    var Component2 = React.createClass({
+    var Component2 = createReactClass({
       render: function () {
         return React.createElement(DocumentTitle, {title: 'irrelevant'},
           React.createElement('div', null,


### PR DESCRIPTION
To prevent React`>=15.5.0` from throwing warnings we can't use `React.createClass` or `React.PropTypes` directly. For both there are now separate packages on npm. In case of `createClass` the recommendation is to convert to a ES6 class, however that's a bit more of an involved change. Instead, I reckon we can get this version out and silence those warnings first and then tackle a conversion to ES6 class separately.

Note: linter and all tests pass, but a warning is thrown by React **during tests** about calling a used PropType directly. However, I can't seem to figure out why, so it's probably caused by `react-side-effect`?