### PR TITLE
Use prop-types; don't use React.createClass (React 15.5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react'),
+    PropTypes = require('prop-types'),
     withSideEffect = require('react-side-effect');
 
 function reducePropsToState(propsList) {
@@ -17,13 +18,12 @@ function handleStateChangeOnClient(title) {
   }
 }
 
-var DocumentTitle = React.createClass({
-  displayName: 'DocumentTitle',
+function DocumentTitle() {
+  React.Component.call(this);
+}
 
-  propTypes: {
-    title: React.PropTypes.string.isRequired
-  },
-
+DocumentTitle.prototype = Object.assign(Object.create(React.Component.prototype), {
+  constructor: DocumentTitle,
   render: function render() {
     if (this.props.children) {
       return React.Children.only(this.props.children);
@@ -32,6 +32,10 @@ var DocumentTitle = React.createClass({
     }
   }
 });
+
+DocumentTitle.propTypes = {
+  title: PropTypes.string.isRequired
+};
 
 module.exports = withSideEffect(
   reducePropsToState,

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function handleStateChangeOnClient(title) {
 
 function DocumentTitle() {
   React.Component.call(this);
+  this.displayName = 'DocumentTitle';
 }
 
 DocumentTitle.prototype = Object.assign(Object.create(React.Component.prototype), {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "react": "^0.13.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.0",
+    "react": "^15.5.0",
     "react-side-effect": "^1.0.2"
   }
 }


### PR DESCRIPTION
* Use the `prop-types` library to avoid React 15.5 deprecation warning.
* Use janky ES5 class syntax in lieu of deprecated `React.createClass` API
