### PR TITLE
Show page title in Chrome browser history

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function reducePropsToState(propsList) {
 function handleStateChangeOnClient(title) {
   var nextTitle = title || '';
   if (nextTitle !== document.title) {
+    history.replaceState(null, '');
     document.title = nextTitle;
   }
 }


### PR DESCRIPTION
The library behaves as expected in Safari & Firefox. However, in Chrome (`58.0.3029.110`) the title appears in Recently Closed, back button history but in Recently Visited and Show Full History the original static page title is saved.

Solution has been found on [stackoverflow](https://stackoverflow.com/a/42749178/862426)