### PR TITLE
update readme to bring more attention to server rendering leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This component can be used on server side as well.
 
 Built with [React Side Effect](https://github.com/gaearon/react-side-effect).
 
+**IMPORTANT NOTE ON SERVER RENDERING:** Please read [this](#server-usage) to prevent creating a memory leak.
+
 ====================
 
 ## Installation


### PR DESCRIPTION
Our team had been using this library for quite some time, on the client. When we switched to server-rendering months later, we unknowingly created a memory leak, since we didn't read through the server-rendering portion when we first implemented.

I think a warning at the top could help properly warn people who may not be server rendering NOW, but could be in the future.

Wdyt?