### PR TITLE
Add DocumentTitle import to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Dependencies: React >= 0.13.0
 Assuming you use something like [react-router](https://github.com/rackt/react-router):
 
 ```javascript
+import DocumentTitle from 'react-document-title'
+
 function App() {
   // Use "My Web App" if no child overrides this
   return (


### PR DESCRIPTION
This demonstrates how to import the component. It's easy enough to look up or even guess, but this avoids that ambiguity.