### PR TITLE
Only set prop types in non-production builds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,11 @@ function DocumentTitle() {}
 DocumentTitle.prototype = Object.create(React.Component.prototype);
 
 DocumentTitle.displayName = 'DocumentTitle';
-DocumentTitle.propTypes = {
-  title: PropTypes.string.isRequired
-};
+if (process.env.NODE_ENV !== 'production') {
+  DocumentTitle.propTypes = {
+    title: PropTypes.string.isRequired
+  };
+}
 
 DocumentTitle.prototype.render = function() {
   if (this.props.children) {


### PR DESCRIPTION
This will enable a bundler to omit the prop-types import. I don't think any tool is set up to actually do this (recognize the import is unused and eliminate it before bundling) but it'll save a few bytes either way.