### PR TITLE
Updating react-side-effect dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "prop-types": "^15.5.6",
-    "react-side-effect": "^1.0.2"
+    "react-side-effect": "^2.1.0"
   }
 }


### PR DESCRIPTION
Upgrading react-side-effect to pick up the fix for deprecated lifecycle method use warnings in react v16.9.